### PR TITLE
Fix a corner case to create duplicates via refreshing

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -302,7 +302,7 @@ $(document).ready(function() {
 
   // should emit the event 'remove user' to server when user leaves/refreshes page
   window.addEventListener("beforeunload", function (e) {
-    socket.emit('remove user', {googleUserID: gUserID, studySpace: chosenSpace, posting: userPosting});
+    socket.emit('remove user', {googleUserID: gUserID, studySpace: chosenSpace, posting: userPosting, socketID: socket});
     return;
   });
 

--- a/server.js
+++ b/server.js
@@ -199,23 +199,27 @@ io.on('connection', function(socket) {
       var publicUserID = info.googleUserID;
       var studySpace = info.studySpace;
       var posting = info.posting;
+      var socketID = info.socketID;
 
-      if(spaceDict[studySpace] != null && spaceDict[studySpace] != undefined) {
-        // remove the user in this space by publicUserID
-        var list = spaceDict[studySpace];
-        spaceDict[studySpace] = list.filter(el => el[0] !== publicUserID);
-        delete googleDict[publicUserID];
-      }
+      if(googleDict[publicUserID][0] == socketID){
 
-      //added stuff to delete added things in activeUsers
-      if(activeUsers.has(publicUserID)){
-        activeUsers.delete(publicUserID);
-      }
+        if(spaceDict[studySpace] != null && spaceDict[studySpace] != undefined) {
+          // remove the user in this space by publicUserID
+          var list = spaceDict[studySpace];
+          spaceDict[studySpace] = list.filter(el => el[0] !== publicUserID);
+          delete googleDict[publicUserID];
+        }
 
-      // clear timed interval for 'show space stuff' socket emission
-      if (showSpaceInterval != null) {
-        clearInterval(showSpaceInterval);
-      }
+        //added stuff to delete added things in activeUsers
+        if(activeUsers.has(publicUserID)){
+          activeUsers.delete(publicUserID);
+        }
+
+        // clear timed interval for 'show space stuff' socket emission
+        if (showSpaceInterval != null) {
+          clearInterval(showSpaceInterval);
+        }
+    }
     });
 
 

--- a/server.js
+++ b/server.js
@@ -201,7 +201,7 @@ io.on('connection', function(socket) {
       var posting = info.posting;
       var socketID = info.socketID;
 
-      if(googleDict[publicUserID][0] == socketID){
+      if(googleDict[publicUserID] !== null && googleDict[publicUserID][0] == socketID){
 
         if(spaceDict[studySpace] != null && spaceDict[studySpace] != undefined) {
           // remove the user in this space by publicUserID


### PR DESCRIPTION
Fix the following bug:

> If you refresh the “duplicate” page, the site allows the duplicate user to go through. Reproduction steps:
> (1) have two windows open
> (2) log into course connect with first window
> (3) refresh the second window (this causes the user's ID to be removed from "activeUsers" on the server)
> (4) second window can now connect because "activeUsers" doesn't have that user ID anymore
> (5) now you still have duplicate users